### PR TITLE
Change 1P Start button mapping to Return

### DIFF
--- a/source/unix/input.cpp
+++ b/source/unix/input.cpp
@@ -884,7 +884,7 @@ void input_set_default() {
 	player[0].l = SDL_GetScancodeFromName("Left");
 	player[0].r = SDL_GetScancodeFromName("Right");
 	player[0].select = SDL_GetScancodeFromName("Right Shift");
-	player[0].start = SDL_GetScancodeFromName("Right Ctrl");
+	player[0].start = SDL_GetScancodeFromName("Return");
 	player[0].a = SDL_GetScancodeFromName("Z");
 	player[0].b = SDL_GetScancodeFromName("A");
 	player[0].ta = SDL_GetScancodeFromName("X");


### PR DESCRIPTION
There are many keyboards, including Mac and some Windows laptops, with no `Right Ctrl` key. Here I suggest changing default 1P Start button mapping to `Return` key which nice aligns with `Right Shift` Select button.

It might be confusing for some existing users, but wouldn't affect too much since they should already have their `input.conf` saved. I think it's important to have more universal default anyways.