### PR TITLE
Fix desktop entry

### DIFF
--- a/source/unix/icons/nestopia.desktop
+++ b/source/unix/icons/nestopia.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Nestopia
 Comment=Accurate NES Emulator
-Exec=nestopia -e
+Exec=nestopia -e %f
 Icon=nestopia
 Terminal=false
 Type=Application


### PR DESCRIPTION
I want to open nes file with nestopia from nautilus, but the exec key of nestopia.desktop doesn't have %f field.
See also http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html