### PR TITLE
Save last folder used with GTK File Chooser

### DIFF
--- a/source/unix/config.cpp
+++ b/source/unix/config.cpp
@@ -131,6 +131,7 @@ void config_file_write() {
 		fprintf(fp, "genie_distortion=%d\n", conf.misc_genie_distortion);
 		fprintf(fp, "disable_gui=%d\n", conf.misc_disable_gui);
 		fprintf(fp, "config_pause=%d\n", conf.misc_config_pause);
+		fprintf(fp, "gtk_file_chooser_last_folder=%s\n", conf.gtk_file_chooser_last_folder);		
 		
 		fclose(fp);
 	}
@@ -202,6 +203,7 @@ void config_set_default() {
 	#ifdef _APPLE
 	conf.misc_config_pause = true; // Always pause on OS X
 	#endif
+	conf.gtk_file_chooser_last_folder = NULL;
 }
 
 static int config_match(void* user, const char* section, const char* name, const char* value) {
@@ -263,6 +265,7 @@ static int config_match(void* user, const char* section, const char* name, const
 	else if (MATCH("misc", "genie_distortion")) { pconfig->misc_genie_distortion = atoi(value); }
 	else if (MATCH("misc", "disable_gui")) { pconfig->misc_disable_gui = atoi(value); }
 	else if (MATCH("misc", "config_pause")) { pconfig->misc_config_pause = atoi(value); }
+	else if (MATCH("misc", "gtk_file_chooser_last_folder")) { pconfig->gtk_file_chooser_last_folder = strdup(value); }	
     
 	else { return 0; }
 	return 1;

--- a/source/unix/config.h
+++ b/source/unix/config.h
@@ -59,6 +59,7 @@ typedef struct {
 	bool misc_genie_distortion;
 	bool misc_disable_gui;
 	bool misc_config_pause;
+	char* gtk_file_chooser_last_folder;
 } settings_t;
 
 void config_file_read();

--- a/source/unix/gtkui/gtkui_dialogs.cpp
+++ b/source/unix/gtkui/gtkui_dialogs.cpp
@@ -22,12 +22,16 @@
 
 #include "../main.h"
 #include "../video.h"
+#include "../config.h"
 
 #include "gtkui.h"
 #include "gtkui_cheats.h"
 
 extern nstpaths_t nstpaths;
 extern GtkWidget *gtkwindow;
+extern settings_t conf;
+
+gchar *currentFolder = NULL;
 
 void gtkui_file_open() {
 	// Open a file using a GTK+ dialog
@@ -40,6 +44,9 @@ void gtkui_file_open() {
 				GTK_STOCK_OPEN,
 				GTK_RESPONSE_ACCEPT,
 				NULL);
+	
+	if(conf.gtk_file_chooser_last_folder != NULL)
+		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), conf.gtk_file_chooser_last_folder);
 	
 	GtkFileFilter *filter = gtk_file_filter_new();
 	
@@ -66,6 +73,7 @@ void gtkui_file_open() {
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 		char *filename;
 		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+		conf.gtk_file_chooser_last_folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog));
 		gtk_widget_destroy(dialog);
 		nst_load(filename);
 		g_free(filename);

--- a/source/unix/gtkui/gtkui_dialogs.cpp
+++ b/source/unix/gtkui/gtkui_dialogs.cpp
@@ -71,6 +71,10 @@ void gtkui_file_open() {
 	if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_ACCEPT) {
 		char *filename;
 		filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+		
+		if(conf.gtk_file_chooser_last_folder != NULL)
+			free(conf.gtk_file_chooser_last_folder);
+			
 		conf.gtk_file_chooser_last_folder = gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(dialog));
 		gtk_widget_destroy(dialog);
 		nst_load(filename);

--- a/source/unix/gtkui/gtkui_dialogs.cpp
+++ b/source/unix/gtkui/gtkui_dialogs.cpp
@@ -31,8 +31,6 @@ extern nstpaths_t nstpaths;
 extern GtkWidget *gtkwindow;
 extern settings_t conf;
 
-gchar *currentFolder = NULL;
-
 void gtkui_file_open() {
 	// Open a file using a GTK+ dialog
 	GtkWidget *dialog = gtk_file_chooser_dialog_new(


### PR DESCRIPTION
Hi,

Just a tiny change to keep the path of last used folder with GTK File Chooser under Linux.
This prevent from having to select the ROM folder each time opening a ROM.

Folder path is kept in config file.

Regards