### PR TITLE
Separate freedesktop.org-specific files from program-specific files (CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ if ( HAS_NO_NARROWING )
 	target_compile_options( nestopia PRIVATE -Wno-narrowing )
 endif()
 
-target_compile_definitions( nestopia PRIVATE -DDATADIR=\"${CMAKE_INSTALL_FULL_DATADIR}/nestopia\" -DNST_PRAGMA_ONCE )
+target_compile_definitions( nestopia PRIVATE -DDATADIR=\"${CMAKE_INSTALL_FULL_DATADIR}/nestopia\" -DDATAROOTDIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}\" -DNST_PRAGMA_ONCE )
 target_include_directories( nestopia PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source )
 
 # pkg-config for a number of libraries
@@ -409,15 +409,19 @@ endif()
 ################
 # Installation #
 ################
+# program-specific files
 install( TARGETS nestopia                         DESTINATION ${CMAKE_INSTALL_BINDIR} )
 install( FILES NstDatabase.xml                    DESTINATION ${CMAKE_INSTALL_DATADIR}/nestopia )
-install( FILES source/unix/icons/nestopia.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications )
-install( FILES source/unix/icons/nestopia32.png   DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps RENAME nestopia.png )
-install( FILES source/unix/icons/nestopia48.png   DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/48x48/apps RENAME nestopia.png )
-install( FILES source/unix/icons/nestopia64.png   DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/64x64/apps RENAME nestopia.png )
-install( FILES source/unix/icons/nestopia96.png   DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/96x96/apps RENAME nestopia.png )
-install( FILES source/unix/icons/nestopia128.png  DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps RENAME nestopia.png )
-install( FILES source/unix/icons/nestopia.svg     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps RENAME nestopia.svg )
+
+# freedesktop.org-specific files
+install( FILES source/unix/icons/nestopia.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications )
+install( FILES source/unix/icons/nestopia32.png   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps RENAME nestopia.png )
+install( FILES source/unix/icons/nestopia48.png   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps RENAME nestopia.png )
+install( FILES source/unix/icons/nestopia64.png   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps RENAME nestopia.png )
+install( FILES source/unix/icons/nestopia96.png   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/96x96/apps RENAME nestopia.png )
+install( FILES source/unix/icons/nestopia128.png  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps RENAME nestopia.png )
+install( FILES source/unix/icons/nestopia.svg     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps )
+install( FILES source/unix/icons/nespad.svg       DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps )
 
 # documentation
 install( FILES AUTHORS ChangeLog README.md README.unix DESTINATION ${CMAKE_INSTALL_DOCDIR} )

--- a/source/unix/gtkui/gtkui.cpp
+++ b/source/unix/gtkui/gtkui.cpp
@@ -419,8 +419,8 @@ GtkWidget *gtkui_about() {
 
 void gtkui_image_paths() {
 	// Set paths to SVG icons/images
-	snprintf(iconpath, sizeof(iconpath), "%s/icons/nestopia.svg", DATADIR);
-	snprintf(padpath, sizeof(padpath), "%s/icons/nespad.svg", DATADIR);
+	snprintf(iconpath, sizeof(iconpath), "%s/icons/hicolor/scalable/apps/nestopia.svg", DATAROOTDIR);
+	snprintf(padpath, sizeof(padpath), "%s/icons/hicolor/scalable/apps/nespad.svg", DATAROOTDIR);
 	
 	// Load the SVG from local source dir if make install hasn't been done
 	struct stat svgstat;


### PR DESCRIPTION
Hey @rdanbrook 
I have another few number of small fixes for the CMake port. Some of the directories were incorrectly specified.

* Some distributions prefer to separate files into these two categories
  and require it as a matter of QA. DATADIR is used for program-specific
  files, whereas freedesktop.org-specific should be relative to DATAROOTDIR
  https://blogs.gnome.org/hughsie/2014/06/16/datarootdir-v-s-datadir/
* Fix paths in .cpp files that were misspecified
* Install missing 'nespad.svg' file