### PR TITLE
add adapter autoselect using NstDatabase

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1066,6 +1066,7 @@ bool retro_load_game(const struct retro_game_info *info)
       Api::Input(emulator).AutoSelectController(1);
       Api::Input(emulator).AutoSelectController(2);
       Api::Input(emulator).AutoSelectController(3);
+      Api::Input(emulator).AutoSelectAdapter();
    }
    else
    {


### PR DESCRIPTION
fixes 4-player Famicom games