### PR TITLE
Fixes automatic rom patching for gui and cli (path problem)

### DIFF
--- a/source/unix/main.cpp
+++ b/source/unix/main.cpp
@@ -665,17 +665,17 @@ bool nst_archive_handle(const char *filename, char **rom, int *romsize, const ch
 	return false;
 }
 
-bool nst_find_patch(char *filename) {
+bool nst_find_patch(char *filename, const char *gamedir) {
 	// Check for a patch in the same directory as the game
 	FILE *file;
 	
 	if (!conf.misc_soft_patching) { return 0; }
 	
-	snprintf(filename, sizeof(nstpaths.savename), "%s.ips", nstpaths.gamename);
+	snprintf(filename, 512, "%s/%s.ips", gamedir, nstpaths.gamename);
 	
 	if ((file = fopen(filename, "rb")) != NULL) { fclose(file); return 1; }
 	else {
-		snprintf(filename, sizeof(nstpaths.savename), "%s.ups", nstpaths.gamename);
+		snprintf(filename, 512, "%s/%s.ups", gamedir, nstpaths.gamename);
 		if ((file = fopen(filename, "rb")) != NULL) { fclose(file); return 1; }
 	}
 	
@@ -814,7 +814,7 @@ void nst_load(const char *filename) {
 		// Set the file paths
 		nst_set_paths(filename);
 		
-		if (nst_find_patch(patchname)) { // Load with a patch if there is one
+		if (nst_find_patch(patchname, dirname((char*)filename))) { // Load with a patch if there is one
 			std::ifstream pfile(patchname, std::ios::in|std::ios::binary);
 			Machine::Patch patch(pfile, false);
 			result = machine.Load(file, nst_default_system(), patch);

--- a/source/unix/main.h
+++ b/source/unix/main.h
@@ -16,7 +16,7 @@ typedef struct {
 
 bool nst_archive_checkext(const char *filename);
 bool nst_archive_handle(const char *filename, char **rom, int *romsize, const char *reqfile);
-bool nst_find_patch(char *filename);
+bool nst_find_patch(char *filename, const char *gamedir);
 void nst_load_db();
 void nst_load_fds_bios();
 void nst_load_palette(const char *filename);


### PR DESCRIPTION
The ips/ups patching only worked from cli when called from the same
folder as the rom. It is because the rom path was never taken into
account, so it was a relative path, i.e. your pwd had to be in the rom
folder for patching to work. Now it should always work, I hope.