### PR TITLE
Fix nst_find_patch code for dirname

### DIFF
--- a/source/unix/main.h
+++ b/source/unix/main.h
@@ -16,7 +16,7 @@ typedef struct {
 
 bool nst_archive_checkext(const char *filename);
 bool nst_archive_handle(const char *filename, char **rom, int *romsize, const char *reqfile);
-bool nst_find_patch(char *filename, const char *gamedir);
+bool nst_find_patch(char *patchname, unsigned int patchname_length, const char *filename);
 void nst_load_db();
 void nst_load_fds_bios();
 void nst_load_palette(const char *filename);


### PR DESCRIPTION
I forgot, dirname can modify its argument, so I have to make a copy of filename since it is const. Now it should be bulletproof, unless I made any error. I haven't written c code in a long time!