### PR TITLE
Fix logic error introduced in some warning cleanup

### DIFF
--- a/source/core/NstMachine.cpp
+++ b/source/core/NstMachine.cpp
@@ -278,8 +278,13 @@ namespace Nes
 
 					bool acknowledged = true;
 
-					if (image && ((image->GetDesiredSystem((state & Api::Machine::NTSC) ? REGION_NTSC : REGION_PAL))) == (SYSTEM_FAMICOM || SYSTEM_DENDY))
-						acknowledged = false;
+					if (image)
+					{
+						System desiredSystem = image->GetDesiredSystem((state & Api::Machine::NTSC) ? REGION_NTSC : REGION_PAL);
+
+						if (desiredSystem == SYSTEM_FAMICOM || desiredSystem == SYSTEM_DENDY)
+							acknowledged = false;
+					}
 
 					ppu.Reset( hard, acknowledged );
 


### PR DESCRIPTION
Commit e76799382d5469ebb1a28d8412c97a19b5c6f38a introduced a small
logic error in the machine handling.  Fix it to the originally intended
logic.