### PR TITLE
Menubar fades to black each time gl area is redrawn on freeBSD.

### DIFF
--- a/source/unix/gtkui/gtkui.cpp
+++ b/source/unix/gtkui/gtkui.cpp
@@ -82,6 +82,9 @@ static void gtkui_glarea_realize(GtkGLArea *glarea) {
 
 static void gtkui_swapbuffers() {
 	gtk_widget_queue_draw(drawingarea);
+	#ifdef __FreeBSD__
+	gtk_widget_queue_draw(menubar);
+	#endif
 	ogl_render();
 }
 


### PR DESCRIPTION
Possible issue in gtk3 widget on freeBSD (seen on several applications with gl area widget). If window has a gl area, menu bar becomes black each time gl area is updated (even if they do not overlap). User has to blindly click in order to find necessary menu item. Can be mitigated by redrawing menu bar explicitly.
Environment: FreeBSD 12.0-current, X11, IceWM