### PR TITLE
Update NstBoardAcclaimMcAcc.hpp

### DIFF
--- a/source/core/board/NstBoardAcclaimMcAcc.hpp
+++ b/source/core/board/NstBoardAcclaimMcAcc.hpp
@@ -40,7 +40,7 @@ namespace Nes
 		{
 			namespace Acclaim
 			{
-				class NST_NO_VTABLE McAcc : public Board
+				class McAcc : public Board
 				{
 				public:
 


### PR DESCRIPTION
This fixes the McAcc games and allows them to run on the new mapper. Tested and verified.