### PR TITLE
Add JACK audio support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ if( NOT CMAKE_BUILD_TYPE )
 	set( CMAKE_BUILD_TYPE "Release" )
 endif()
 
+# add module for jack
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
+
 # Adhere to GNU filesystem layout conventions
 include( GNUInstallDirs )
 
@@ -376,6 +379,13 @@ elseif( APPLE )
 
 elseif( UNIX )
 	# most likely, building on Unix
+	find_package(Jack)
+	if( JACK_FOUND )
+		target_compile_definitions( nestopia PRIVATE -D_JACK )
+		target_include_directories( nestopia PRIVATE ${JACK_INCLUDE_DIRS} )
+		target_compile_options( nestopia PRIVATE ${JACK_DEFINITIONS} )
+		target_link_libraries( nestopia ${JACK_LIBRARIES} )
+	endif( JACK_FOUND )
 	# GTK+3
 	option( ENABLE_GTK "Build GTK+3 based UI" ON )
 	if( ENABLE_GTK )

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,11 @@ nestopia_CPPFLAGS += -D_GTK $(GTK3_CFLAGS)
 nestopia_LDADD += $(GTK3_LIBS)
 endif
 
+if ENABLE_JACK
+nestopia_CPPFLAGS += -D_JACK $(JACK_CFLAGS)
+nestopia_LDADD += $(JACK_LIBS)
+endif
+
 ################
 # Installation #
 ################

--- a/cmake/Modules/FindJack.cmake
+++ b/cmake/Modules/FindJack.cmake
@@ -1,0 +1,82 @@
+# - Try to find jack-2.6
+# Once done this will define
+#
+#  JACK_FOUND - system has jack
+#  JACK_INCLUDE_DIRS - the jack include directory
+#  JACK_LIBRARIES - Link these to use jack
+#  JACK_DEFINITIONS - Compiler switches required for using jack
+#
+#  Copyright (c) 2008 Andreas Schneider <mail@cynapses.org>
+#  Modified for other libraries by Lasse Kärkkäinen <tronic>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
+  # in cache already
+  set(JACK_FOUND TRUE)
+else (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  if (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+    include(UsePkgConfig)
+    pkgconfig(jack _JACK_INCLUDEDIR _JACK_LIBDIR _JACK_LDFLAGS _JACK_CFLAGS)
+  else (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+      pkg_check_modules(_JACK jack)
+    endif (PKG_CONFIG_FOUND)
+  endif (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_MINOR_VERSION} EQUAL 4)
+  find_path(JACK_INCLUDE_DIR
+    NAMES
+      jack/jack.h
+    PATHS
+      ${_JACK_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+  )
+
+  find_library(JACK_LIBRARY
+    NAMES
+      jack
+    PATHS
+      ${_JACK_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  if (JACK_LIBRARY AND JACK_INCLUDE_DIR)
+    set(JACK_FOUND TRUE)
+
+    set(JACK_INCLUDE_DIRS
+      ${JACK_INCLUDE_DIR}
+    )
+
+    set(JACK_LIBRARIES
+      ${JACK_LIBRARIES}
+      ${JACK_LIBRARY}
+    )
+
+  endif (JACK_LIBRARY AND JACK_INCLUDE_DIR)
+
+  if (JACK_FOUND)
+    if (NOT JACK_FIND_QUIETLY)
+      message(STATUS "Found jack: ${JACK_LIBRARY}")
+    endif (NOT JACK_FIND_QUIETLY)
+  else (JACK_FOUND)
+    if (JACK_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find JACK")
+    endif (JACK_FIND_REQUIRED)
+  endif (JACK_FOUND)
+
+  # show the JACK_INCLUDE_DIRS and JACK_LIBRARIES variables only in the advanced view
+  mark_as_advanced(JACK_INCLUDE_DIRS JACK_LIBRARIES)
+
+endif (JACK_LIBRARIES AND JACK_INCLUDE_DIRS)
+

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,15 @@ PKG_CHECK_MODULES([SDL2], [sdl2])
 dnl LibEpoxy
 PKG_CHECK_MODULES([LIBEPOXY], [epoxy])
 
+dnl JACK audio
+AC_ARG_WITH([jack],
+	AS_HELP_STRING([--with-jack], [Build with JACK audio support]))
+
+AS_IF([test "x$with_jack" = "xyes"], [
+	PKG_CHECK_MODULES([JACK],[jack])
+])
+AM_CONDITIONAL([ENABLE_JACK], [test "x$with_jack" = "xyes"])
+
 dnl GTK3
 AC_ARG_ENABLE([gui],
 	AS_HELP_STRING([--disable-gui], [Disable building GUI with GTK+3]))

--- a/source/unix/config.cpp
+++ b/source/unix/config.cpp
@@ -87,7 +87,7 @@ void config_file_write() {
 		
 		// Audio
 		fprintf(fp, "[audio]\n");
-		fprintf(fp, "; 0=SDL, 1=libao\n");
+		fprintf(fp, "; 0=SDL, 1=libao, 2=jack\n");
 		fprintf(fp, "api=%d\n\n", conf.audio_api);
 		fprintf(fp, "; Valid values are 1 and 0.\n");
 		fprintf(fp, "stereo=%d\n\n", conf.audio_stereo);

--- a/source/unix/gtkui/gtkui_config.cpp
+++ b/source/unix/gtkui/gtkui_config.cpp
@@ -450,6 +450,9 @@ GtkWidget *gtkui_config() {
 				NULL);
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_audio_api), "SDL");
 	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_audio_api), "libao");
+	#ifdef _JACK
+	gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_audio_api), "jack");
+	#endif
 		
 	gtk_combo_box_set_active(GTK_COMBO_BOX(combo_audio_api), conf.audio_api);
 	


### PR DESCRIPTION
This allows use of the JACK audio backend. JACK support
will be built by cmake if found, or the --with-jack option
to the configure script.

JACK audio will set the sample rate for audio equal to
the jack server's sample rate. It also connects to the first
two physical output ports for playback.