### PR TITLE
Fix a segfault on input with no game loaded

### DIFF
--- a/source/unix/input.cpp
+++ b/source/unix/input.cpp
@@ -268,6 +268,10 @@ void input_pulse_turbo(Input::Controllers *controllers) {
 }
 
 void input_inject(Input::Controllers *controllers, nesinput_t input) {
+	// If there is no game loaded this is still called. Do a noop if this is the case
+	if(controllers == NULL) {
+		return;
+	}
 	// Insert the input signal into the NES
 	if (input.pressed) {
 		controllers->pad[input.player].buttons |= input.nescode;


### PR DESCRIPTION
I think this fixes issue #245 and #264 

If you hit an input button on a controller, but no game was loaded input_inject would be called with NULL as the controller pointer. This checks for this condition.

Perhaps the "proper" way would be never to try to inject input at all when no game is loaded, but I didn't see any quick and easy way to determine if a game is loaded or not.